### PR TITLE
Added a timeout in seconds parameter for scripts

### DIFF
--- a/Payload_Type/apfell/apfell/agent_functions/run_perl.py
+++ b/Payload_Type/apfell/apfell/agent_functions/run_perl.py
@@ -35,6 +35,26 @@ class RunPerlArguments(TaskArguments):
                     )
                 ]
             ),
+            CommandParameter(
+                name="timeout", 
+                cli_name="timeout", 
+                display_name="Timeout in Seconds",
+                default_value=1800,
+                type=ParameterType.Number,
+                description="The amount of seconds after which the script will be terminated if no output has been returned.",
+                parameter_group_info=[
+                    ParameterGroupInfo(
+                        required=False,
+                        group_name="Default",
+                        ui_position=1
+                    ),
+                    ParameterGroupInfo(
+                        required=False,
+                        group_name="Existing File",
+                        ui_position=1
+                    )
+                ]
+            ),
         ]
 
     async def parse_arguments(self):

--- a/Payload_Type/apfell/apfell/agent_functions/run_python.py
+++ b/Payload_Type/apfell/apfell/agent_functions/run_python.py
@@ -35,6 +35,26 @@ class RunPythonArguments(TaskArguments):
                     )
                 ]
             ),
+            CommandParameter(
+                name="timeout", 
+                cli_name="timeout", 
+                display_name="Timeout in Seconds",
+                default_value=1800,
+                type=ParameterType.Number,
+                description="The amount of seconds after which the script will be terminated if no output has been returned.",
+                parameter_group_info=[
+                    ParameterGroupInfo(
+                        required=False,
+                        group_name="Default",
+                        ui_position=1
+                    ),
+                    ParameterGroupInfo(
+                        required=False,
+                        group_name="Existing File",
+                        ui_position=1
+                    )
+                ]
+            ),
         ]
 
     async def parse_arguments(self):

--- a/Payload_Type/apfell/apfell/agent_functions/run_ruby.py
+++ b/Payload_Type/apfell/apfell/agent_functions/run_ruby.py
@@ -35,6 +35,26 @@ class RunRubyArguments(TaskArguments):
                     )
                 ]
             ),
+            CommandParameter(
+                name="timeout",
+                cli_name="timeout",
+                display_name="Timeout in Seconds",
+                default_value=1800,
+                type=ParameterType.Number,
+                description="The amount of seconds after which the script will be terminated if no output has been returned.",   
+                parameter_group_info=[
+                    ParameterGroupInfo(
+                        required=False,
+                        group_name="Default",
+                        ui_position=1
+                    ),
+                    ParameterGroupInfo(
+                        required=False,
+                        group_name="Existing File",
+                        ui_position=1
+                    )
+                ]
+            ),
         ]
 
     async def parse_arguments(self):

--- a/Payload_Type/apfell/apfell/agent_functions/run_script.py
+++ b/Payload_Type/apfell/apfell/agent_functions/run_script.py
@@ -75,6 +75,26 @@ class RunScriptArguments(TaskArguments):
                     )
                 ]
             ),
+            CommandParameter(
+                name="timeout", 
+                cli_name="timeout", 
+                display_name="Timeout in Seconds",
+                default_value=1800,
+                type=ParameterType.Number,
+                description="The amount of seconds after which the script will be terminated if no output has been returned.",
+                parameter_group_info=[
+                    ParameterGroupInfo(
+                        required=False,
+                        group_name="Existing File",
+                        ui_position=3
+                    ),
+                    ParameterGroupInfo(
+                        required=False,
+                        group_name="New File",
+                        ui_position=3
+                    )
+                ]
+            ),
         ]
 
     async def parse_arguments(self):


### PR DESCRIPTION
Added a new parameter to run_script, run_ruby, run_perl, and run_python and the run_script.js files so that if a script becomes unresponsive for a certain period of time, the scripting task will be terminated avoiding hanging the Apfell beacon.